### PR TITLE
fix: clamped negative box values to 0.0 instead of throwing

### DIFF
--- a/cv_tensor_process/yolo_v8_process/qrb_yolo_process_lib/include/bounding_box.hpp
+++ b/cv_tensor_process/yolo_v8_process/qrb_yolo_process_lib/include/bounding_box.hpp
@@ -27,7 +27,7 @@ public:
     MAX
   };
 
-  BoundingBox(const std::vector<float> & box, const BoxFmt fmt);
+  BoundingBox(const std::vector<float> & bbox, const BoxFmt fmt);
   ~BoundingBox() = default;
 
   BBoxCoords to_tlwh_coords() const;

--- a/cv_tensor_process/yolo_v8_process/qrb_yolo_process_lib/src/bounding_box.cpp
+++ b/cv_tensor_process/yolo_v8_process/qrb_yolo_process_lib/src/bounding_box.cpp
@@ -9,21 +9,20 @@
 
 namespace qrb::yolo_process
 {
-BoundingBox::BoundingBox(const BBoxCoords & box, BoxFmt fmt)
+BoundingBox::BoundingBox(const BBoxCoords & bbox, BoxFmt fmt)
 {
-  if (box.size() != 4) {
+  const int box_size = 4;
+  if (bbox.size() != box_size) {
     std::ostringstream oss;
-    oss << "Invalid bounding box, expected 4 elements but got " << box.size() << " elements."
+    oss << "Invalid bounding box, expected 4 elements but got " << bbox.size() << " elements."
         << std::endl;
     throw std::invalid_argument(oss.str());
   }
-
-  if (box[0] < 0 || box[1] < 0 || box[2] < 0 || box[3] < 0) {
-    std::ostringstream oss;
-    oss << "Invalid bounding box: (";
-    std::copy(box.begin(), box.end(), std::ostream_iterator<float>(oss, ","));
-    oss << ")" << std::endl;
-    throw std::invalid_argument(oss.str());
+  BBoxCoords box = bbox;
+  for (int n = 0; n < box_size; ++n) {
+    if (box[n] < 0.0) {
+      box[n] = 0.0;
+    }
   }
 
   float tl_x, tl_y, br_x, br_y;
@@ -55,7 +54,7 @@ BoundingBox::BoundingBox(const BBoxCoords & box, BoxFmt fmt)
   }
   box_arr_ = { tl_x, tl_y, br_x, br_y };
 
-  if (tl_x < 0 || tl_y < 0 || br_x < tl_x || br_y < tl_y) {
+  if (tl_x < 0.0f || tl_y < 0.0f || br_x < tl_x || br_y < tl_y) {
     std::ostringstream oss;
     oss << "Invalid bounding box(TLBR): (";
     std::copy(box_arr_.begin(), box_arr_.end(), std::ostream_iterator<float>(oss, ","));


### PR DESCRIPTION
The YOLO model may output negative coordinate values when the detected object is located at the edge of the image. Clamped negative box values to 0.0 instead of throwing.